### PR TITLE
Removing airplane.dev

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,6 @@ A curated list of awesome runbook documents, guidebooks, software, and resources
 
 ## Runbook Software
 
-- [Airplane](https://airplane.dev) - A developer infrastructure for internal tools. It enables developers to automate workflows and tasks.
 - [Azure Automation](https://azure.microsoft.com/en-us/products/automation) - A process automation tool provided by Microsoft Azure.
 - [Datadog Workflow Automation](https://www.datadoghq.com/product/workflow-automation/) - An automation software for remediation processes.
 - [Doctor Droid](https://github.com/DrDroidLab/playbooks) - A framework for automating investigations.


### PR DESCRIPTION
As of 2024, Airplane has been [shut down](https://yolken.net/blog/end-of-airplanedev) after an [acquisition by Airtable](https://www.airtable.com/newsroom/company/airplane-balsa-join-airtable). The [Hacker News thread](https://news.ycombinator.com/item?id=38861271) suggests several alternatives, though I don't have experience with them, so I won't add any replacements in the `readme.md`.

## Changes
* Remove airplane.dev from the `readme.md`